### PR TITLE
[REVERTED] add dynamic fork settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM qmkfm/qmk_cli
-# test layout ADD layout_src ./layout_src
-# TODO would be nice to make this whole action more reusable parameterising `qmk setup`
-RUN qmk setup zsa/qmk_firmware -b firmware20 -y
+ARG FORK=zsa/qmk_firmware
+ARG BRANCH
+RUN git clone ${BRANCH:+-b $BRANCH --single-branch} --recurse-submodules https://github.com/${FORK}.git /qmk_firmware
+RUN qmk setup -y
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,6 @@
 name: 'ORYX QMK Firmware Compiler Action (zsa only)'
 author: 'Phoscur'
 description: 'Compiles QMK Firmware from ORYX source'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'
 branding:
   icon: 'settings'  
   color: 'orange'
@@ -23,4 +20,29 @@ inputs:
   keyboard:
     description: 'Keyboard type'
     default: 'moonlander'
-  
+  fork:
+    description: 'Fork of QMK on Github'
+    default: 'zsa/qmk_firmware'
+  branch:
+    description: 'Branch of fork. Uses default branch when empty'
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout the commit
+      uses: actions/checkout@v2
+
+    - name: Build QMK container
+      run: docker compose build
+      shell: bash
+      env:
+        FORK=${{ inputs.fork }}
+        BRANCH=${{ inputs.branch }}
+
+    - name: Compile Keyboard
+      run: docker compose run qmk
+      shell: bash
+      env:
+        INPUT_PATH=${{ inputs.path }}
+        INPUT_ARTIFACTS_PATH=${{ inputs.artifacts_path }}
+        INPUT_KEYMAP=${{ inputs.keymap }}
+        INPUT_KEYBOARD=${{ inputs.keyboard }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.4'
+services:
+  qmk:
+    build:
+      context: .
+      args:
+        FORK: ${FORK}
+        BRANCH: ${BRANCH}
+      volumes:
+        - ${GITHUB_WORKSPACE}:/github/workspace
+      working_dir: /github/workspace

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,6 @@ ARTIFACTS_PATH="${INPUT_ARTIFACTS_PATH:-artifacts}"
 KEYMAP="${INPUT_KEYMAP:-neo}"
 KEYBOARD="${INPUT_KEYBOARD:-moonlander}"
 
-#echo "Setting up ZSA QMK fork ..."
-# moved into Dockerfile, TODO make configurable
-#qmk setup zsa/qmk_firmware -b firmware20
 echo "Adding keymap $KEYMAP [$KEYBOARD] ..."
 qmk new-keymap -kb $KEYBOARD -km $KEYMAP
 


### PR DESCRIPTION
notes:
- the basic docker action has no build arg support so i had to run the docker cmds manually
- when you don't set a branch with the qmk setup cmd it defaults to master, which won't work with zsa/qmk_firmware
  that's why I'm cloning forks manually with git, because it always clones the latest default branch.
  that way you don't have to hardcode the firmware version, which was already outdated