### PR TITLE
Dynamic Fork & Firmware Round #2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM qmkfm/qmk_cli
-# test layout ADD layout_src ./layout_src
-# TODO would be nice to make this whole action more reusable parameterising `qmk setup`
-RUN qmk setup zsa/qmk_firmware -b firmware20 -y
+ARG FORK=zsa/qmk_firmware
+ARG BRANCH
+RUN git clone ${BRANCH:+-b $BRANCH --single-branch} --recurse-submodules https://github.com/${FORK}.git /qmk_firmware
+RUN qmk setup -y
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,6 @@
 name: 'ORYX QMK Firmware Compiler Action (zsa only)'
 author: 'Phoscur'
 description: 'Compiles QMK Firmware from ORYX source'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'
 branding:
   icon: 'settings'  
   color: 'orange'
@@ -23,4 +20,34 @@ inputs:
   keyboard:
     description: 'Keyboard type'
     default: 'moonlander'
-  
+  fork:
+    description: 'Fork of QMK on Github'
+    default: 'zsa/qmk_firmware'
+  branch:
+    description: 'Branch of fork. Uses default branch when empty'
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout the commit
+      uses: actions/checkout@v3
+      with: 
+        repository: Phoscur/QMK-Compile
+        path: ./QMK-Compile
+
+    - name: Build QMK container
+      run: docker compose build
+      working-directory: ./QMK-Compile
+      shell: bash
+      env:
+        FORK: ${{ inputs.fork }}
+        BRANCH: ${{ inputs.branch }}
+
+    - name: Compile Keyboard
+      run: docker compose up
+      working-directory: ./QMK-Compile
+      shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_ARTIFACTS_PATH: ${{ inputs.artifacts_path }}
+        INPUT_KEYMAP: ${{ inputs.keymap }}
+        INPUT_KEYBOARD: ${{ inputs.keyboard }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.7'
+services:
+  qmk:
+    working_dir: ${GITHUB_WORKSPACE}
+    environment:
+      INPUT_PATH: ${INPUT_PATH}
+      INPUT_ARTIFACTS_PATH: ${INPUT_ARTIFACTS_PATH}
+      INPUT_KEYMAP: ${INPUT_KEYMAP}
+      INPUT_KEYBOARD: ${INPUT_KEYBOARD}
+    volumes:
+      - ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}
+    build:
+      context: .
+      args:
+        FORK: ${FORK}
+        BRANCH: ${BRANCH}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,6 @@ ARTIFACTS_PATH="${INPUT_ARTIFACTS_PATH:-artifacts}"
 KEYMAP="${INPUT_KEYMAP:-neo}"
 KEYBOARD="${INPUT_KEYBOARD:-moonlander}"
 
-#echo "Setting up ZSA QMK fork ..."
-# moved into Dockerfile, TODO make configurable
-#qmk setup zsa/qmk_firmware -b firmware20
 echo "Adding keymap $KEYMAP [$KEYBOARD] ..."
 qmk new-keymap -kb $KEYBOARD -km $KEYMAP
 


### PR DESCRIPTION
actions/checkout@v3 was overwriting the workdir which also deleted the layout_src folder
fix: checkout to subfolder with `path: ./QMK-Compile`

```
volumes:
      - ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}
```
I decided to mount the github workspace folder at the same path to mimic the basic docker action behvaiour.
Now the parent can specify the artifact path as a full path (same inside the container used by entrypoint.sh) or as a relative path because of `working_dir: ${GITHUB_WORKSPACE}`

I saw you wanted to add a fallback branch to firmware21 but that's the same as hardcoding the branch.
IMHO it's best to keep it empty as default to clone the latest default branch from zsa, which is always stable and backwards compatible.

> Here is another idea that came up: Do we want [oryx download](https://github.com/Phoscur/oryx-macro-hax/blob/main/oryx-downloader.ts) as a separate/sibling or derived GA?
I think it's better as a workflow step and keep everything in one repo instead of bloating it up.

Check out my take on [oryx-macro-hax](https://github.com/5andr0/oryx-macro-hax)
I'm only extracting the relevant keymap files directly to layout_src, so you don't have to specify the layout folder every time as secret and inside the my-macros.ts . OryxId as input is enough. Also having my-illicit-macros for local edits was redundant.

Is there a reason you wanted the setup part inside the dockerfile? To my knowledge the docker image cannot be cached anyway, so you could do the setup inside entrypoint.sh where you have access to environment vars instead of build args. Then you can use the basic docker container again and safe a lot of code. See https://github.com/Phoscur/QMK-compile/pull/4

Tested with and without fork / branch parameters. Checked the build console output and flashed the firmware to my moonlander with f20 and f21