### PR TITLE
dynamic fork & branch - basic version #3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
 FROM qmkfm/qmk_cli
-# test layout ADD layout_src ./layout_src
-# TODO would be nice to make this whole action more reusable parameterising `qmk setup`
-RUN qmk setup zsa/qmk_firmware -b firmware20 -y
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -23,4 +23,8 @@ inputs:
   keyboard:
     description: 'Keyboard type'
     default: 'moonlander'
-  
+  fork:
+    description: 'Fork of QMK on Github'
+    default: 'zsa/qmk_firmware'
+  branch:
+    description: 'Branch of fork. Uses default branch when empty'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,9 @@ ARTIFACTS_PATH="${INPUT_ARTIFACTS_PATH:-artifacts}"
 KEYMAP="${INPUT_KEYMAP:-neo}"
 KEYBOARD="${INPUT_KEYBOARD:-moonlander}"
 
-#echo "Setting up ZSA QMK fork ..."
-# moved into Dockerfile, TODO make configurable
-#qmk setup zsa/qmk_firmware -b firmware20
+echo "Setting up ZSA QMK fork ..."
+git clone ${INPUT_BRANCH:+-b $INPUT_BRANCH --single-branch} --recurse-submodules https://github.com/${INPUT_FORK}.git /qmk_firmware
+qmk setup -y
 echo "Adding keymap $KEYMAP [$KEYBOARD] ..."
 qmk new-keymap -kb $KEYBOARD -km $KEYMAP
 


### PR DESCRIPTION
So that would be the basic version without prebuilding the docker image with build args.
Are there any benefits of having a prebuilt docker image to reuse? I don't think that github will cache this for a faster workflow, so you can simply use this version instead